### PR TITLE
Invalidate activity report when completed

### DIFF
--- a/XcodeIDEKit/XKActivityController.m
+++ b/XcodeIDEKit/XKActivityController.m
@@ -86,7 +86,6 @@
     if (!reporter) return;
     
     [reporter.mutableActivityReports addObject:report.IDEActivityReport];
-    [[self activityReportManager] startObservingReportForCompletion:report.IDEActivityReport];
 }
 
 
@@ -95,9 +94,10 @@
     if (!reporter) return;
     
     report.completed = YES;
+    [report.IDEActivityReport performSelector:@selector(invalidate)];
+    [[self activityReportManager] setLastCompletedUserVisibleSchemeBasedReport:report.IDEActivityReport];
     [[self activityReportManager] reportDidComplete:report.IDEActivityReport];
     [reporter.mutableActivityReports removeObject:report.IDEActivityReport];
-    
 }
 
 


### PR DESCRIPTION
Fix crash stating that `report was never invalidated.`
* Perform selector `invalidate` on activity report, it is an optional
protocol method and compiler does not see it.
* Set the previously invalidated report as the
`lastCompletedUserVisibleSchemeBasedReport` over activity report
manager.